### PR TITLE
Commented out echo, wrapped nested ? : (if/else) to avoid warnings

### DIFF
--- a/iContactProApi.php
+++ b/iContactProApi.php
@@ -209,7 +209,7 @@ class iContactProApi {
 		}
 
 		// Make the call
-		echo("/a/{$this->getCompanyId()}/c/{$this->getProfileId()}/contacts");
+		//echo("/a/{$this->getCompanyId()}/c/{$this->getProfileId()}/contacts");
 		$aContacts = $this->makeCall("/a/{$this->getCompanyId()}/c/{$this->getProfileId()}/contacts", 'POST', array($aContact), 'contacts');
 		// Return the contact
 		return $aContacts[0];
@@ -794,9 +794,9 @@ class iContactProApi {
 			'Accept:  application/json',
 			'Content-type:  application/json',
 			'Api-Version:  ' . (defined('ICP_APIVERSION')       ? constant('ICP_APIVERSION') : '2.2'),
-			'Api-AppId:  '   . (!empty($this->aConfig['appId'])       ? $this->aConfig['appId']         : defined('ICP_APPID') ? constant('ICP_APPID') : ''),
-			'Api-Username:  '. (!empty($this->aConfig['apiUsername']) ? $this->aConfig['apiUsername']   : defined('ICP_APIUSERNAME') ? constant('ICP_APIUSERNAME') : ''),
-			'Api-Password:  '. (!empty($this->aConfig['apiPassword']) ? $this->aConfig['apiPassword']   : defined('ICP_APIPASSWORD') ? constant('ICP_APIPASSWORD') : '')
+			'Api-AppId:  '   . (!empty($this->aConfig['appId'])       ? $this->aConfig['appId']         : (defined('ICP_APPID') ? constant('ICP_APPID') : '')),
+			'Api-Username:  '. (!empty($this->aConfig['apiUsername']) ? $this->aConfig['apiUsername']   : (defined('ICP_APIUSERNAME') ? constant('ICP_APIUSERNAME') : '')),
+			'Api-Password:  '. (!empty($this->aConfig['apiPassword']) ? $this->aConfig['apiPassword']   : (defined('ICP_APIPASSWORD') ? constant('ICP_APIPASSWORD') : ''))
 		);
 	}
 


### PR DESCRIPTION
Commented out an echo in the addContact function.

Wrapped 3 nested ? : (if/else) in their own parentheses to avoid
warnings and API errors:

Severity: Warning

Message: constant(): Couldn't find constant ICP_APPID

Filename: icontact-pro-api-php-master/iContactProApi.php

Line Number: 797

A PHP Error was encountered

Severity: Warning

Message: constant(): Couldn't find constant ICP_APIUSERNAME

Filename: icontact-pro-api-php-master/iContactProApi.php

Line Number: 798

A PHP Error was encountered

Severity: Warning

Message: constant(): Couldn't find constant ICP_APIPASSWORD

Filename: icontact-pro-api-php-master/iContactProApi.php

Line Number: 799

'The iContactPro API did not return valid JSON.'
